### PR TITLE
Added support for ngrams of length > 2

### DIFF
--- a/train_classifier.py
+++ b/train_classifier.py
@@ -8,7 +8,7 @@ from nltk.corpus.reader import CategorizedPlaintextCorpusReader, CategorizedTagg
 from nltk.corpus.util import LazyCorpusLoader
 from nltk.metrics import BigramAssocMeasures, f_measure, masi_distance, precision, recall
 from nltk.probability import FreqDist, ConditionalFreqDist
-from nltk.util import bigrams
+from nltk.util import ngrams
 from nltk_trainer import dump_object
 from nltk_trainer.classification import corpus, scoring
 from nltk_trainer.classification.featx import bag_of_words, bag_of_words_in_set, train_test_feats
@@ -75,7 +75,11 @@ classifier_group.add_argument('--multi', action='store_true', default=False,
 feat_group = parser.add_argument_group('Feature Extraction',
 	'The default is to lowercase every word, strip punctuation, and use stopwords')
 feat_group.add_argument('--bigrams', action='store_true', default=False,
-	help='include bigrams as features')
+	help='include bigrams as features.')
+feat_group.add_argument('--ngrams', action='store', default=1, type=int,
+	help='use n-grams as features.')
+feat_group.add_argument('--nmin-one', action='store_true', default=False,
+	help='use features of length n-gram-1 in action to n-grams.')
 feat_group.add_argument('--no-lowercase', action='store_true', default=False,
 	help="don't lowercase every word")
 feat_group.add_argument('--filter-stopwords', default='no',
@@ -186,7 +190,11 @@ def norm_words(words):
 		words = [w for w in words if w.lower() not in stopset]
 	
 	if args.bigrams:
-		return words + bigrams(words)
+		# If bigrams was passed as an argument, make it behave as it normally does currently.
+		args.ngrams = 2
+		args.nmin_one = True
+	if args.ngrams > 1:
+		return (ngrams(words, args.ngrams - 1) if args.nmin_one else []) + ngrams(words, args.ngrams)
 	else:
 		return words
 


### PR DESCRIPTION
Currently train_classifier only supports unigrams and bigrams. I added support for ngrams of length > 2 but kept the current behaviour of the --bigrams flag.
