### PR TITLE
get correct python environment when running scripts

### DIFF
--- a/analyze_chunked_corpus.py
+++ b/analyze_chunked_corpus.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import argparse
 import nltk.corpus
 from nltk.tree import Tree

--- a/analyze_chunker_coverage.py
+++ b/analyze_chunker_coverage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import argparse, collections, math
 import nltk.corpus, nltk.corpus.reader, nltk.data, nltk.tag, nltk.metrics
 from nltk.corpus.util import LazyCorpusLoader

--- a/analyze_classifier_coverage.py
+++ b/analyze_classifier_coverage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import argparse, collections, itertools, operator, re, string, time
 import cPickle as pickle
 import nltk.data

--- a/analyze_tagged_corpus.py
+++ b/analyze_tagged_corpus.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import argparse
 import nltk.corpus
 from nltk.corpus.util import LazyCorpusLoader

--- a/analyze_tagger_coverage.py
+++ b/analyze_tagger_coverage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import argparse, collections, math, os.path
 import nltk.corpus, nltk.corpus.reader, nltk.data, nltk.tag, nltk.metrics
 from nltk.corpus.util import LazyCorpusLoader

--- a/categorized_corpus2csv.py
+++ b/categorized_corpus2csv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import argparse, csv, os.path
 import nltk_trainer.classification.corpus
 from nltk_trainer import load_corpus_reader

--- a/classify_corpus.py
+++ b/classify_corpus.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import argparse, itertools, operator, os, os.path, string
 import nltk.data
 from nltk.corpus import stopwords

--- a/combine_classifiers.py
+++ b/combine_classifiers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import argparse, os.path
 import nltk.data
 from nltk_trainer import dump_object

--- a/tag_phrases.py
+++ b/tag_phrases.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import argparse, os.path
 import cPickle as pickle
 import nltk.data, nltk.tag

--- a/train_chunker.py
+++ b/train_chunker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import argparse, math, itertools, os.path
 import nltk.tag, nltk.chunk, nltk.chunk.util
 import nltk_trainer.classification.args

--- a/train_classifier.py
+++ b/train_classifier.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import argparse, collections, itertools, math, os.path, re, string, operator
 import nltk.data
 import nltk_trainer.classification.args

--- a/train_tagger.py
+++ b/train_tagger.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import argparse, math, itertools, os.path
 import nltk.corpus, nltk.data
 import nltk_trainer.classification.args

--- a/translate_corpus.py
+++ b/translate_corpus.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import argparse, os, os.path
 import nltk.data
 from nltk.misc import babelfish


### PR DESCRIPTION
This commit pulls in the correct python environment so nltk works for non-standard python installs
