### PR TITLE
Fix missing import word_counts_in_set in train_classifier.py

### DIFF
--- a/train_classifier.py
+++ b/train_classifier.py
@@ -13,7 +13,7 @@ from nltk.util import ngrams
 from nltk_trainer import dump_object, import_attr, load_corpus_reader
 from nltk_trainer.classification import corpus, scoring
 from nltk_trainer.classification.featx import (bag_of_words, bag_of_words_in_set,
-	word_counts, train_test_feats)
+	word_counts, train_test_feats, word_counts_in_set)
 from nltk_trainer.classification.multi import MultiBinaryClassifier
 
 ########################################


### PR DESCRIPTION
I've fixed a missing import word_counts_in_set from nltk_trainer.classification.featx for train_classifier.py.
When using value-type != 'bool' for train_classifier.py the execution path will jump in the else-statement (line 247) and fail on line 251 (missing import).
