### PR TITLE
Pickled Classifier Naming

### DIFF
--- a/train_classifier.py
+++ b/train_classifier.py
@@ -419,11 +419,7 @@ if not args.no_pickle:
 	if args.filename:
 		fname = os.path.expanduser(args.filename)
 	else:
-		corpus_clean = args.corpus
-		if corpus_clean[-1] == '/':
-			corpus_clean = corpus_clean[:-1]
-		import re
-		corpus_clean = re.sub('.*/','',corpus_clean)
+		corpus_clean = os.path.split(args.corpus.rstrip('/'))[1]
 		name = '%s_%s.pickle' % (corpus_clean, '_'.join(args.classifier))
 		fname = os.path.join(os.path.expanduser('~/nltk_data/classifiers'), name)
 	


### PR DESCRIPTION
Case:
./train_classifier ../some_dir/corpus
This will place the classifier as /home/user/nltk_date/classifiers/../some_dir/corpus_NaiveBayes.pickle
which is equal to /home/user/nltk_date/some_dir/corpus_NaiveBayes.pickle

I assume the purpose of NLTK Trainer is to keep all classifiers in nltk_data/classifiers so I fixed the code by regex stripping all leading folders from the corpus name.
