### PR TITLE
Fix analyze_classifier_coverage when using --ngrams parameter 

### DIFF
--- a/analyze_classifier_coverage.py
+++ b/analyze_classifier_coverage.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import argparse, collections, itertools, operator, re, string, time
+import argparse, collections, functools, itertools, operator, re, string, time
 import nltk.data
 from nltk.classify.util import accuracy
 from nltk.corpus import stopwords
@@ -106,8 +106,12 @@ def norm_words(words):
 	if stopset:
 		words = [w for w in words if w.lower() not in stopset]
 
+	# in case we modified words in a generator, ensure it's a list so we can add together
+	if not isinstance(words, list):
+		words = list(words)
+
 	if args.ngrams:
-		return reduce(operator.add, [words if n == 1 else ngrams(words, n) for n in args.ngrams])
+		return functools.reduce(operator.add, [words if n == 1 else list(ngrams(words, n)) for n in args.ngrams])
 	else:
 		return words
 


### PR DESCRIPTION
If you use analyze_classifier_coverage.py with --ngrams parameter (e.g. --ngrams 1 2 3) it throws an exception:
Traceback (most recent call last):
  File "analyze_classifier_coverage.py", line 152, in <module>
    feat = bag_of_words(norm_words(t))
  File "analyze_classifier_coverage.py", line 110, in norm_words
    return reduce(operator.add, [words if n == 1 else ngrams(words, n) for n in args.ngrams])
TypeError: can only concatenate list (not "generator") to list

Made the code consistent with train_classifier.py